### PR TITLE
explicitly added dependency to rtt_typelib

### DIFF
--- a/type_to_vector.orogen
+++ b/type_to_vector.orogen
@@ -3,6 +3,7 @@ name "type_to_vector"
 version "0.1"
 
 using_library 'type_to_vector'
+using_library 'rtt_typelib-gnulinux'
 
 import_types_from 'base'
 import_types_from 'TypeToVectorTypes.hpp'

--- a/type_to_vector.orogen
+++ b/type_to_vector.orogen
@@ -3,7 +3,7 @@ name "type_to_vector"
 version "0.1"
 
 using_library 'type_to_vector'
-using_library 'rtt_typelib-gnulinux'
+using_library "rtt_typelib-#{OroGen.orocos_target}"
 
 import_types_from 'base'
 import_types_from 'TypeToVectorTypes.hpp'


### PR DESCRIPTION
Getting the following error in a rock build with `separate_prefixes: true`:

```
wirkus@MWIRKUS-LAP-U:build[master]$ make
[  2%] Built target check-typekit-uptodate
[ 16%] Built target type_to_vector-typekit-gnulinux
[ 16%] Built target regen-typekit
[ 18%] Building CXX object tasks/CMakeFiles/type_to_vector-tasks-gnulinux.dir/BaseTask.cpp.o
/media/wirkus/Data/development/modeling_buildconf/data_processing/orogen/type_to_vector/tasks/BaseTask.cpp:6:10: fatal error: rtt/typelib/TypelibMarshallerBase.hpp: No such file or directory
 #include <rtt/typelib/TypelibMarshallerBase.hpp>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
tasks/CMakeFiles/type_to_vector-tasks-gnulinux.dir/build.make:134: recipe for target 'tasks/CMakeFiles/type_to_vector-tasks-gnulinux.dir/BaseTask.cpp.o' failed
make[2]: *** [tasks/CMakeFiles/type_to_vector-tasks-gnulinux.dir/BaseTask.cpp.o] Error 1
CMakeFiles/Makefile2:613: recipe for target 'tasks/CMakeFiles/type_to_vector-tasks-gnulinux.dir/all' failed
make[1]: *** [tasks/CMakeFiles/type_to_vector-tasks-gnulinux.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2
```

The PR suggests oroGen to so a pkg-config search for `rtt_typelib-gnulinux` what adds the required include paths. It works then, but hardcoding the target architecture (`gnulinux`) at this point is not so nice.
Any ideas for improvement? 