### PR TITLE
fix: Declare a local using namespace for bind::placeholders

### DIFF
--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -276,6 +276,8 @@ bool BaseTask::createDataInfo(const PortConfig& config) {
 
     DataVector& dv = mVectors.at(config.vectorIdx);
 
+    using namespace boost::placeholders;
+
     aggregator::StreamAligner::Stream<SampleData>::callback_t cb = 
         boost::bind(&BaseTask::sampleCallback,this,_1,_2);
 


### PR DESCRIPTION
Since a similar thing is no longer provided through some include.